### PR TITLE
🪲 Fixed NavBar overflow on medium screen (md)

### DIFF
--- a/pages/components/NavContent.js
+++ b/pages/components/NavContent.js
@@ -5,9 +5,9 @@ import styles from "./Navbar.module.css";
 
 export default function NavContent(props) {
   return (
-    <div className="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
+    <div className="container mx-auto flex flex-wrap p-5 flex-col lg:flex-row items-center">
       <Link href="/">
-        <a className="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0 dark:text-gray-100">
+        <a className="flex title-font font-medium items-center text-gray-900 mb-4 lg:mb-0 dark:text-gray-100">
           <img className="w-6" src="/clueless_logo.png" alt="clueless logo" />
           <span className="ml-3 text-xl ">ClueLess</span>
         </a>
@@ -30,7 +30,7 @@ export default function NavContent(props) {
         </Link>
       </nav>
       <a href="https://github.com/HITK-2025/first-contribution" target="_blank">
-        <button className="font-bold inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none dark:hover:bg-blue-500 hover:text-white hover:bg-blue-500 rounded-xl mt-4 md:mt-0 text-lg transition-all dark:bg-gray-600">
+        <button className="font-bold inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none dark:hover:bg-blue-500 hover:text-white hover:bg-blue-500 rounded-xl mt-4 lg:mt-0 text-lg transition-all dark:bg-gray-600">
           Contibute Now
           <svg
             fill="none"

--- a/pages/components/Theme.js
+++ b/pages/components/Theme.js
@@ -28,7 +28,7 @@ const Theme = (props) => {
     <div>
       {theme === "light" && (
         <button
-          className="bg-black text-white rounded-xl p-2 hover:bg-slate-800 transition-all md:ml-5 mt-3 md:mt-auto"
+          className="bg-black text-white rounded-xl p-2 hover:bg-slate-800 transition-all md:ml-5 mt-3 lg:mt-auto"
           onClick={() => {
             darkTheme();
             try {
@@ -48,7 +48,7 @@ const Theme = (props) => {
       )}
       {theme === "dark" && (
         <button
-          className="bg-white text-black rounded-xl p-2 hover:bg-gray-100 transition-all md:ml-5 mt-3 md:mt-auto"
+          className="bg-white text-black rounded-xl p-2 hover:bg-gray-100 transition-all md:ml-5 mt-3 lg:mt-auto"
           onClick={() => {
             lightTheme();
             try {


### PR DESCRIPTION
flex-row on medium screen size(md) led to Navigation Bar overflow... hence changed updated the code such that Flex-row applies only on large screen size (lg)!

Before:
![Before](https://user-images.githubusercontent.com/96720944/194424485-f153de48-570a-4d1d-b675-125a97d38a84.png)

After:
![After](https://user-images.githubusercontent.com/96720944/194424511-ecb71edc-82d6-439f-afe3-c25f4544cb60.png)
