### PR TITLE
re-ordering clueless team's cards in contributors

### DIFF
--- a/data/contributors.js
+++ b/data/contributors.js
@@ -18,17 +18,6 @@ const contributors = [
         gender : "male"
   },
   {
-    name: "Rajdeep Sengupta",
-    branch: "CSE AI & ML",
-    college: "HITK",
-    year: 2025,
-    linkedin: "https://www.linkedin.com/in/rajdeep-sengupta/",
-    github: "https://github.com/Rajdip019/Rajdip019",
-    gender: "male",
-  },
-  
-  
-  {
     name: "Sattyam Samania",
     branch: "CSE",
     college: "ITM UNIVERSE",
@@ -38,15 +27,7 @@ const contributors = [
     gender: "male",
   },
   
-  {
-    name: "Roshan Kumar",
-    branch: "CSE AI & ML",
-    college: "HITK",
-    year: 2025,
-    linkedin: "https://www.linkedin.com/in/roshan-kumar-176918202/",
-    github: "https://github.com/Roshaen",
-    gender: "male",
-  },
+  
   {
     name: "Aiman Aisha",
     branch: "CSE",
@@ -74,15 +55,7 @@ const contributors = [
     github: "https://github.com/Amit-TheOne",
     gender: "Male",
   },
-  {
-    name: "Nikhil Raj",
-    branch: "CSE AI & ML",
-    college: "HITK",
-    year: 2025,
-    linkedin: "https://www.linkedin.com/in/nikhil-raj-117246232/",
-    github: "https://github.com/nikhil25803",
-    gender: "male",
-  },
+  
   {
     name: "Anubhab Halder",
     branch: "CSE AI & ML",
@@ -126,15 +99,6 @@ const contributors = [
     year: 2025,
     linkedin: "https://www.linkedin.com/in/jyothi-swaroop-makena-024661227/",
     github: "https://github.com/RedJOe-0608",
-    gender: "Male",
-  },
-  {
-    name: "Debajyoti Saha",
-    branch: "CSBS",
-    college: "HITK",
-    year: 2025,
-    linkedin: "https://www.linkedin.com/in/debajyoti-saha-37bb78219/",
-    github: "https://github.com/Debajyoti14",
     gender: "Male",
   },
   {
@@ -1447,4 +1411,40 @@ const contributors = [
 
 ];
 
+contributors.unshift({
+  name: "Rajdeep Sengupta",
+  branch: "CSE AI & ML",
+  college: "HITK",
+  year: 2025,
+  linkedin: "https://www.linkedin.com/in/rajdeep-sengupta/",
+  github: "https://github.com/Rajdip019/Rajdip019",
+  gender: "male",
+  },
+  {
+    name: "Roshan Kumar",
+    branch: "CSE AI & ML",
+    college: "HITK",
+    year: 2025,
+    linkedin: "https://www.linkedin.com/in/roshan-kumar-176918202/",
+    github: "https://github.com/Roshaen",
+    gender: "male",
+  },
+  {
+    name: "Nikhil Raj",
+    branch: "CSE AI & ML",
+    college: "HITK",
+    year: 2025,
+    linkedin: "https://www.linkedin.com/in/nikhil-raj-117246232/",
+    github: "https://github.com/nikhil25803",
+    gender: "male",
+  },
+  {
+    name: "Debajyoti Saha",
+    branch: "CSBS",
+    college: "HITK",
+    year: 2025,
+    linkedin: "https://www.linkedin.com/in/debajyoti-saha-37bb78219/",
+    github: "https://github.com/Debajyoti14",
+    gender: "Male",
+  });
 export default contributors;


### PR DESCRIPTION
Removed clueless team's objects from contributors array and performed an unshift operation to position them at the beginning of array.
We can create seperate array for the team and simply use spread operator to re-order but some users might confuse with this array and contributors array and update. That's the reason i have gone with the approach which uses unshift.
This is how it looks after re-ordering - 
![clueless](https://user-images.githubusercontent.com/62489114/194484104-ee0510b2-b18a-4850-9545-ecbb4bde1127.PNG)
